### PR TITLE
Stylus coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 .vagrant/
+src/htmlcov
+.coverage
 *.pyc
+src/assets/css/custom.css

--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
 echo "Updating apt repositories..."
+add-apt-repository ppa:chris-lea/node.js
 apt-get update
 
 
 echo "Installing base packages..."
 PACKAGES="build-essential zsh git vim-nox tree htop libjpeg-dev libfreetype6-dev graphviz gettext"
-PACKAGES="$PACKAGES python python-setuptools python-pip python-dev"
+PACKAGES="$PACKAGES python python-setuptools python-pip python-dev nodejs"
 PACKAGES="$PACKAGES postgresql-9.3 postgresql-server-dev-9.3"
 
 apt-get install -y $PACKAGES
@@ -54,6 +55,10 @@ REQUIREMENTS_FILE=/home/vagrant/src/requirements/devel.txt
 if [ -f "$REQUIREMENTS_FILE" ]; then
     sudo -Hu vagrant bash -c "source $VIRTUALENV_DIR/bin/activate && pip install -r $REQUIREMENTS_FILE"
 fi
+
+
+echo "Installing Stylus css precompiler..."
+npm install stylus -g
 
 
 echo "Creating Django project..."

--- a/src/assets/css/custom.styl
+++ b/src/assets/css/custom.styl
@@ -1,0 +1,1 @@
+//project's stylus code

--- a/src/requirements/devel.txt
+++ b/src/requirements/devel.txt
@@ -2,3 +2,4 @@
 
 # Development tools
 django-debug-toolbar
+coverage==3.7.1


### PR DESCRIPTION
# Tareas relacionadas

[Ajustar branch para integrar stylus y coverage a Luke](http://manoderecha.net/md/index.php/task/94865)
# Descripción del problema o característica:

Integrar características de la rama stylus-coverage
# Descripción de la solución:
- Instalación de nodejs y stylus en provisionamiento
- Tarea para compilar css usando stylus
- Integración de coverage a los requerimientos de development
- Tarea para ejecutar los tests de django y mostrarlos en HTML
# Pruebas
- Se descargó el repositorio en la rama stylus-coverage, modificando las variables mencionadas en la documentación.
- Se levantó la maquina virtual usando `vagrant up` (es necesario provisionar)
- Se inicializó el proyecto `fab environment:vagrant bootstrap`
- Se modifico la variable project_tools, cambiando el valor de la llave is_using_stylus
- Se ejecutaron las tareas de fabric `runserver`, `styluscompile`
- También se ejecuto la tarea `runtests`.

Todo se ejecuto correctamente
