### PR TITLE
(md:96082) Fix bug found in fabric settings file

### DIFF
--- a/environments.json
+++ b/environments.json
@@ -5,7 +5,7 @@
         "site_dir": "/home/vagrant/src/",
         "django_settings": "luke.settings.devel",
         "command_prefixes": [
-            "../env/bin/activate"
+            "/home/vagrant/env/bin/activate"
         ]
     }
 }


### PR DESCRIPTION
# Tareas Relacionadas

Corregir error encontrado en herramienta Luke.
## Descripción del problema

When installing a new luke environment, fabric had problems finding the env directory to call the activate command
## Descripción de la solución

Modify the path where "command_prefixes" was pointing.
## Plan de pruebas

Tested in local computer and the system worked as intended 
