### PR TITLE
(md:96557) Añadir funcionalidad a Luke para inspeccionar bases de datos

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -211,3 +211,15 @@ def register_deployment(commit, branch):
             '--component path:. vcs:git rev:%s branch:%s '
             % (commit, branch)
         )
+
+@task
+def startapp(app_name):
+    """
+    Create a new app inside the Django project
+
+    Usage:
+
+    >>> fab environment:vagrant start_app:'app_name'
+    """
+    with virtualenv():
+        run(join('python manage.py startapp', app_name))

--- a/fabfile.py
+++ b/fabfile.py
@@ -223,3 +223,22 @@ def startapp(app_name):
     """
     with virtualenv():
         run(join('python manage.py startapp', app_name))
+
+@task
+def inspectdb(filename=""):
+    """
+    Allows the inspection of legacy databases inside Django projects
+
+    Usage:
+
+    >>> fab environment:vagrant inspectdb
+    Print the models needed to work with the database
+
+    >>> fab environment:vagrant inspectdb:'filename'
+    Use 'filename' as the output file
+    """
+    with virtualenv():
+        if(filename == ""):
+            run('python manage.py inspectdb')
+        else:
+            run(join('python manage.py inspectdb > ', filename))

--- a/provision/templates/django/settings_base.py
+++ b/provision/templates/django/settings_base.py
@@ -53,7 +53,7 @@ WSGI_APPLICATION = '${PROJECT_NAME}.wsgi.application'
 
 
 # Database
-# https://docs.djangoproject.com/en/1.7/ref/settings/#databases
+# https://docs.djangoproject.com/en/1.8/ref/settings/#databases
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',
@@ -62,7 +62,7 @@ DATABASES = {
 }
 
 # Internationalization
-# https://docs.djangoproject.com/en/1.7/topics/i18n/
+# https://docs.djangoproject.com/en/1.8/topics/i18n/
 LANGUAGE_CODE = 'en-us'
 
 TIME_ZONE = 'UTC'
@@ -75,7 +75,7 @@ USE_TZ = True
 
 
 # Static files (CSS, JavaScript, Images)
-# https://docs.djangoproject.com/en/1.7/howto/static-files/
+# https://docs.djangoproject.com/en/1.8/howto/static-files/
 STATIC_URL = '/assets/'
 
 STATICFILES_DIRS = (
@@ -88,7 +88,7 @@ STATIC_ROOT = os.path.realpath(
 
 
 # Template directories
-# See https://docs.djangoproject.com/en/1.7/ref/settings/#template-dirs
+# See https://docs.djangoproject.com/en/1.8/ref/settings/#template-dirs
 TEMPLATE_DIRS = (
     os.path.realpath(os.path.join(BASE_DIR, '..', 'templates')),
 )

--- a/provision/templates/django/settings_devel.py
+++ b/provision/templates/django/settings_devel.py
@@ -23,7 +23,7 @@ MIDDLEWARE_CLASSES += (
 
 
 # Database
-# https://docs.djangoproject.com/en/1.7/ref/settings/#databases
+# https://docs.djangoproject.com/en/1.8/ref/settings/#databases
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql_psycopg2',

--- a/src/requirements/base.txt
+++ b/src/requirements/base.txt
@@ -1,5 +1,5 @@
 # Core
-Django>=1.7,<1.8
+Django>=1.8,<1.9
 psycopg2>=2.6,<2.7
 
 # Packages


### PR DESCRIPTION
# Tareas relacionadas

[(md:96557) Añadir funcionalidad a Luke para inspeccionar bases de datos](http://manoderecha.net/md/index.php/task/96557)
## Descripción del problema

El archivo fabfile.py no contiene funcionalidades para inspeccionar bases de datos existentes y crear modelos a partir de ellas
## Descripcion de la solución

Añadida la funcionalidad como un task dentro del archivo
## Plan de pruebas

Se comprobaron las nuevas funcionalidades dentro de la computadora local utilizando una base de datos MySQL llena anteriormente. Todo funcionó correctamente

![image](https://cloud.githubusercontent.com/assets/1808194/8418151/d7edf0b4-1e76-11e5-8e37-d41623a0edd1.png)

![image](https://cloud.githubusercontent.com/assets/1808194/8418195/1b7cdd22-1e77-11e5-90e3-b939e72db467.png)
