### PR TITLE
(md:114285) Update the template of django settings to 1.8 version

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -5,9 +5,9 @@ from fabric.context_managers import contextmanager, shell_env
 from fabric.utils import puts
 
 from fabutils import arguments, join, options
-from fabutils.env import set_env_from_json_file
 from fabutils.context import cmd_msg
-from fabutils.tasks import ulocal, urun, ursync_project
+from fabutils.env import set_env_from_json_file
+from fabutils.tasks import ulocal, ursync_project, urun
 from fabutils.text import SUCCESS_ART
 
 

--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -30,14 +30,17 @@ service nginx restart
 
 
 echo "Installing Oh My Zsh!..."
+PROJECT_NAME=luke
 OHMYZSH_DIR=/home/vagrant/.oh-my-zsh
 
 if [ ! -d $OHMYZSH_DIR ]; then
     sudo -Hu vagrant bash -c "git clone https://github.com/robbyrussell/oh-my-zsh.git $OHMYZSH_DIR"
 fi
 
+export PROJECT_NAME
+echo "$(envsubst < /tmp/templates/zsh/zprofile)" > /home/vagrant/.zprofile
 cp /tmp/templates/zsh/zshrc /home/vagrant/.zshrc
-cp /tmp/templates/zsh/zprofile /home/vagrant/.zprofile
+
 chown vagrant:vagrant /home/vagrant/.zshrc
 chown vagrant:vagrant /home/vagrant/.zprofile
 chsh -s $(which zsh) vagrant
@@ -64,7 +67,6 @@ fi
 
 
 echo "Creating Django project..."
-PROJECT_NAME=luke
 PROJECT_DIR=/home/vagrant/src/$PROJECT_NAME
 
 if [ ! -d  "$PROJECT_DIR" ]; then

--- a/provision/templates/django/settings_base.py
+++ b/provision/templates/django/settings_base.py
@@ -3,30 +3,32 @@
 Django settings for ${PROJECT_NAME} project.
 
 For more information on this file, see
-https://docs.djangoproject.com/en/1.7/topics/settings/
+https://docs.djangoproject.com/en/1.8/topics/settings/
 
 For the full list of settings and their values, see
-https://docs.djangoproject.com/en/1.7/ref/settings/
+https://docs.djangoproject.com/en/1.8/ref/settings/
 """
+
 import os
 
-
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
-BASE_DIR = os.path.dirname(os.path.dirname(__file__))
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
+
+# Quick-start development settings - unsuitable for production
+# See https://docs.djangoproject.com/en/1.8/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = '*p_&!3^v6@n_&wy7l_ewpe3e-6cxg@qa-38hw9uu=k$u0f=w7f'
+SECRET_KEY = '*+a9uub1)_lc7)fxhba4$%g2#&shao3o))4=_t&k7dyrr3)l47'
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
-
-TEMPLATE_DEBUG = True
 
 ALLOWED_HOSTS = []
 
 
 # Application definition
+
 INSTALLED_APPS = (
     'django.contrib.admin',
     'django.contrib.auth',
@@ -47,13 +49,34 @@ MIDDLEWARE_CLASSES = (
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 )
 
+
 ROOT_URLCONF = '${PROJECT_NAME}.urls'
+
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'DIRS': [
+            os.path.realpath(os.path.join(BASE_DIR, 'templates'))
+        ],
+        'APP_DIRS': True,
+        'OPTIONS': {
+            'context_processors': [
+                'django.template.context_processors.debug',
+                'django.template.context_processors.request',
+                'django.contrib.auth.context_processors.auth',
+                'django.contrib.messages.context_processors.messages',
+            ],
+            'debug': DEBUG,
+        },
+    },
+]
 
 WSGI_APPLICATION = '${PROJECT_NAME}.wsgi.application'
 
 
 # Database
 # https://docs.djangoproject.com/en/1.8/ref/settings/#databases
+
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',
@@ -61,8 +84,10 @@ DATABASES = {
     }
 }
 
+
 # Internationalization
 # https://docs.djangoproject.com/en/1.8/topics/i18n/
+
 LANGUAGE_CODE = 'en-us'
 
 TIME_ZONE = 'UTC'
@@ -76,6 +101,7 @@ USE_TZ = True
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/1.8/howto/static-files/
+
 STATIC_URL = '/assets/'
 
 STATICFILES_DIRS = (
@@ -84,11 +110,4 @@ STATICFILES_DIRS = (
 
 STATIC_ROOT = os.path.realpath(
     os.path.join(BASE_DIR, '..', '..', 'media', 'assets')
-)
-
-
-# Template directories
-# See https://docs.djangoproject.com/en/1.8/ref/settings/#template-dirs
-TEMPLATE_DIRS = (
-    os.path.realpath(os.path.join(BASE_DIR, '..', 'templates')),
 )

--- a/provision/templates/django/settings_local.py
+++ b/provision/templates/django/settings_local.py
@@ -2,13 +2,13 @@
 """
 Django development settings for ${PROJECT_NAME} project.
 """
-from . import *
+from . import * # noqa
 
 
 # Debug
 DEBUG = True
 
-TEMPLATE_DEBUG = DEBUG
+TEMPLATES[0]['OPTIONS']['debug'] = DEBUG
 
 
 # Application definition

--- a/provision/templates/zsh/zprofile
+++ b/provision/templates/zsh/zprofile
@@ -5,4 +5,4 @@ source /home/vagrant/env/bin/activate
 cd /home/vagrant/src
 
 # Automatically load the proper Django settings
-export DJANGO_SETTINGS_MODULE=luke.settings.local
+export DJANGO_SETTINGS_MODULE=${PROJECT_NAME}.settings.local


### PR DESCRIPTION
### Tareas relacionadas.

[Actualizar el template settings.py para Django 1.8.](http://manoderecha.net/md/index.php/task/114285)
### Descripción del problema o característica.

El template que se usa como base para crear el proyecto Django en luke marca warnings por configuraciones que ya no se utilizan en la versión 1.8 de Django.
### Descripción de la solución.

Modificar el archivo settings_base.py y settings_local.py en la carpeta provision/templates/django. Se corrigieron errores en el archivo fabfile.py
### Pruebas.

Se descargó la versión de luke y se siguieron los pasos escritos en el readme del proyecto: 
- `mkdir demo`
- `cd demo`
- `wget https://github.com/angellagunas/luke/archive/update-django-template-in-provision.tar.gz -O - | tar -xz --strip 1`
- Se cambió el nombre del proyecto en los lugares mencionados en el readme.
- `vagrant up`
- `fab environment:vagrant bootstrap`
- `fab environment:vagrant runserver`
- El proyecto funcionó correctamente sin mostrar alertas.
  ![lukerunserver](https://cloud.githubusercontent.com/assets/8205953/16282360/0f59f174-388e-11e6-8836-329066b48514.png)
