### PR TITLE
(md:127811) Fixes installation of package django debug toolbar

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Simple scripts and templates for scaffolding a basic Django project
     # myproject/environments.json
     {
         "vagrant": {
-            "django_settings": "myproject.settings.devel",
+            "django_settings": "myproject.settings.local",
         }
     }
     ```
@@ -66,13 +66,25 @@ Simple scripts and templates for scaffolding a basic Django project
     $ fab environment:vagrant bootstrap
     ```
 
-6. Run the development server
+6. Add the following in the file myproject/urls.py for configure django debug toolbar
+
+    ```python
+    import django.conf import settings
+
+    if settings.DEBUG:
+        import debug_toolbar
+        urlpatterns += [
+            url(r'^__debug__/', include(debug_toolbar.urls)),
+        ]
+    ```
+
+7. Run the development server
     
     ```bash
     $ fab environment:vagrant runserver
     ```
 
-7. Init your repository
+8. Init your repository
 
     ```bash
     $ git init

--- a/provision/templates/django/settings_local.py
+++ b/provision/templates/django/settings_local.py
@@ -34,4 +34,4 @@ DATABASES = {
 
 
 # Debug toolbar
-INTERNAL_IPS = ('10.0.2.2',)
+INTERNAL_IPS = ('127.0.0.1',)


### PR DESCRIPTION
## Tareas relacionadas
* [[luke] Los settings para el proyecto ambiente local no existen y el complemento django debug toolbar nunca se inicia.](http://manoderecha.net/md/index.php/task/127811)

## Descripción del problema
Al crear la tarea estaba creyendo que en lugar del archivo `settings/local.py` se estaba creando el archivo `settings/devel.py` pero no era así debido a que no se estaban cargando desde las plantillas actualizadas ya que previamente había instalado el proyecto. Al destruir la maquina virtual y comenzar de nuevo con la clonación del repositorio el problema desapareció.

El problema de esta tarea solo consiste en la correcta configuración del complemento django debug toolbar.

## Descripción de la solución
Se agrega la IP interna `127.0.0.1` al diccionario de `INTERNAL_IPS` y en el readme se agrega un paso de instalación para agregar las urls del paquete de django debug toolbar.

## Plan de pruebas
Destruí nuevamente el entorno de desarrollo y volví a crearlo  y ahora el seguir los nuevos pasos el proyecto esta corriendo y ahora aparece la barra de debug en el proyecto.

![captura de pantalla de 2017-03-07 13 19 04](https://cloud.githubusercontent.com/assets/3606807/23673652/ab01de32-0338-11e7-9696-d054e47103f3.png)
