### PR TITLE
(md:128624) update django to 1.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Simple scripts and templates for scaffolding a basic Django project
 6. Add the following in the file myproject/urls.py for configure django debug toolbar
 
     ```python
-    import django.conf import settings
+    from django.conf import settings
 
     if settings.DEBUG:
         import debug_toolbar

--- a/provision/templates/django/settings_base.py
+++ b/provision/templates/django/settings_base.py
@@ -3,10 +3,10 @@
 Django settings for ${PROJECT_NAME} project.
 
 For more information on this file, see
-https://docs.djangoproject.com/en/1.8/topics/settings/
+https://docs.djangoproject.com/en/1.9/topics/settings/
 
 For the full list of settings and their values, see
-https://docs.djangoproject.com/en/1.8/ref/settings/
+https://docs.djangoproject.com/en/1.9/ref/settings/
 """
 
 import os
@@ -16,7 +16,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 
 # Quick-start development settings - unsuitable for production
-# See https://docs.djangoproject.com/en/1.8/howto/deployment/checklist/
+# See https://docs.djangoproject.com/en/1.9/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = '*+a9uub1)_lc7)fxhba4$%g2#&shao3o))4=_t&k7dyrr3)l47'
@@ -75,7 +75,7 @@ WSGI_APPLICATION = '${PROJECT_NAME}.wsgi.application'
 
 
 # Database
-# https://docs.djangoproject.com/en/1.8/ref/settings/#databases
+# https://docs.djangoproject.com/en/1.9/ref/settings/#databases
 
 DATABASES = {
     'default': {
@@ -86,7 +86,7 @@ DATABASES = {
 
 
 # Internationalization
-# https://docs.djangoproject.com/en/1.8/topics/i18n/
+# https://docs.djangoproject.com/en/1.9/topics/i18n/
 
 LANGUAGE_CODE = 'en-us'
 
@@ -100,7 +100,7 @@ USE_TZ = True
 
 
 # Static files (CSS, JavaScript, Images)
-# https://docs.djangoproject.com/en/1.8/howto/static-files/
+# https://docs.djangoproject.com/en/1.9/howto/static-files/
 
 STATIC_URL = '/assets/'
 

--- a/provision/templates/django/settings_local.py
+++ b/provision/templates/django/settings_local.py
@@ -23,7 +23,7 @@ MIDDLEWARE_CLASSES += (
 
 
 # Database
-# https://docs.djangoproject.com/en/1.8/ref/settings/#databases
+# https://docs.djangoproject.com/en/1.9/ref/settings/#databases
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql_psycopg2',

--- a/provision/templates/django/settings_testing.py
+++ b/provision/templates/django/settings_testing.py
@@ -18,7 +18,7 @@ INSTALLED_APPS += (
 )
 
 # Database
-# https://docs.djangoproject.com/en/1.8/ref/settings/#databases
+# https://docs.djangoproject.com/en/1.9/ref/settings/#databases
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql_psycopg2',

--- a/src/requirements/base.txt
+++ b/src/requirements/base.txt
@@ -1,9 +1,9 @@
 # Core
-Django>=1.8,<1.9
+Django>=1.9,<1.10
+django-extensions>=1.6,<1.7
 psycopg2>=2.6,<2.7
-pillow
+pillow>=3.1,<3.2
 
 # Packages
 ipython
-django-extensions
 Werkzeug

--- a/src/requirements/local.txt
+++ b/src/requirements/local.txt
@@ -1,4 +1,4 @@
 -r base.txt
 
 # Development tools
-django-debug-toolbar
+django-debug-toolbar==1.6


### PR DESCRIPTION
### Tareas relacionadas.
[Update luke to django 1.9.](http://manoderecha.net/md/index.php/task/128624)

### Descripción del problema o característica.
Es necesario que los nuevos proyectos se creen con la nueva versión estable de Django.

### Descripción de la solución.
Actualizar todos los archivos donde se menciona o instala Django 1.8

### Pruebas.
Se creo un nuevo proyecto siguiendo los pasos descritos en el README
![captura de pantalla de 2017-03-29 18 34 53](https://cloud.githubusercontent.com/assets/8205953/24482493/d1c1abb0-14ae-11e7-9449-e7994d86ceed.png)

