### PR TITLE
Update api to django 1 9

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Luke
-Simple scripts and templates for scaffolding a basic Django project
+Simple scripts and templates for scaffolding a basic Django project.
 
 
 ## Prerequisites
@@ -10,37 +10,17 @@ Simple scripts and templates for scaffolding a basic Django project
 + [fabutils](https://github.com/vinco/fabutils)
 
 
-## Usage
+## Install
 1. Download the repository's tarball and extract it to your project's directory
 
     ```bash
     $ mkdir myproject
     $ cd myproject
-    $ wget https://github.com/vinco/luke/archive/master.tar.gz -O - | tar -xz --strip 1
+    $ wget https://github.com/vinco/luke/archive/api.tar.gz -O - | tar -xz --strip 1
     ```
 
 2. Set your project's name in `evironments.json`, `fabfile.py` and `provision/provision.sh`
-
-    ```json
-    # myproject/environments.json
-    {
-        "vagrant": {
-            "django_settings": "myproject.settings.local",
-        }
-    }
-    ```
-
-    ```python
-    # myproject/fabfile.py
-    ...
-    # urun('createdb luke -l en_US.UTF-8 -E UTF8 -T template0')
-    urun('createdb myproject -l en_US.UTF-8 -E UTF8 -T template0')
-    ... 
-    # urun('dropdb luke')
-    urun('dropdb myproject')
-    ...
-    ```
-
+    
     ```bash
     # myproject/provision/provision.sh
     ...
@@ -54,7 +34,8 @@ Simple scripts and templates for scaffolding a basic Django project
     ```bash
     $ vagrant up
     ```
-4. Redirect the required domains to your localhost
+4. Redirect the required domains to your localhost (optional)
+
     ```bash
     # /etc/hosts
     192.168.33.2  http://luke.local/
@@ -66,80 +47,25 @@ Simple scripts and templates for scaffolding a basic Django project
     $ fab environment:vagrant bootstrap
     ```
 
-6. Add the following in the file myproject/urls.py for configure django debug toolbar
-
-    ```python
-    from django.conf import settings
-
-    if settings.DEBUG:
-        import debug_toolbar
-        urlpatterns += [
-            url(r'^__debug__/', include(debug_toolbar.urls)),
-        ]
-    ```
-
-7. Run the development server
+6. Run the development server
     
     ```bash
     $ fab environment:vagrant runserver
     ```
 
-8. Init your repository
+7. Init your repository
 
     ```bash
     $ git init
     ```
 
 
-# Testing
+# Test your project
 
-1. Set your project's name in `tox.ini`.
-    
-    ```bash
-    # change name
-    application-import-names = myproject
-
-    DJANGO_SETTINGS_MODULE = myproject.settings.testing
-
-    norecursedirs =
-        .*
-        src/requirements
-        src/myproject/settings
-    ```
-
-1. Open vagrant environment from ssh:
-    ```bash
-    $ vagrant ssh
-    ```
-
-2. Change directory to `/vagrant`:
-    ```bash
-    $ cd /vagrant
-    ```
-
-3. Install tox inside the virtual machine:
-    ```bash
-    $ pip install tox
-    ```
-
-4. Run the proper command with tox:
-
+1. Run command.
+```bash
+    $ fab environment:vagrant runtests
 ```
-# Run the full test suite including the PEP8 linter.
-$ tox
-
-# Run only the PEP8 linter.
-$ tox -e py27-flake8
-
-# Run only the test suite.
-$ tox -e py27-django
-
-# Pass -r flag to recreate the virtual environment when requirements changes.
-$ tox -r
-
-# Run the test suite to a specific file.
-$ tox -e py27-django src/luke/core/api/tests/test_serializers.py
-
 
 ## Usage API
 
@@ -465,5 +391,3 @@ router.register(
     TodoViewSet,
     base_name="todos"
 )
-
-```

--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -102,6 +102,9 @@ if [ ! -d  "$PROJECT_DIR" ]; then
     cp -r /tmp/templates/django/utils $PROJECT_DIR
     cp -r /tmp/templates/django/core $PROJECT_DIR
     cp -r /tmp/templates/django/api $PROJECT_DIR
+
+    echo "$(envsubst < /tmp/templates/django/api/urls.py)" > $PROJECT_DIR/api/urls.py
+
     chown -R vagrant:vagrant $PROJECT_DIR/..
 fi
 

--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -78,6 +78,7 @@ if [ ! -d  "$PROJECT_DIR" ]; then
     echo "$(envsubst < /tmp/templates/django/settings_local.py)" > $PROJECT_DIR/settings/local.py
     echo "$(envsubst < /tmp/templates/django/settings_staging.py)" > $PROJECT_DIR/settings/staging.py
     echo "$(envsubst < /tmp/templates/django/settings_testing.py)" > $PROJECT_DIR/settings/testing.py
+    echo "$(envsubst < /tmp/templates/tox/tox.ini)" > /home/vagrant/tox.ini
 
     cp -r /tmp/templates/django/utils $PROJECT_DIR
     cp -r /tmp/templates/django/core $PROJECT_DIR

--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -42,9 +42,13 @@ echo "$(envsubst < /tmp/templates/zsh/zprofile)" > /home/vagrant/.zprofile
 cp /tmp/templates/zsh/zshrc /home/vagrant/.zshrc
 
 
+echo "Copying fabfile, tox, environments and bower configs..."
 echo "$(envsubst < /tmp/templates/fabric/fabfile.py)" > /vagrant/fabfile.py           
 echo "$(envsubst < /tmp/templates/tox/tox.ini)" > /vagrant/tox.ini                    
 echo "$(envsubst < /tmp/templates/env/environments.json)" > /vagrant/environments.json
+
+echo "$(envsubst < /tmp/templates/bower/bower.json)" > /vagrant/bower.json
+echo "$(envsubst < /tmp/templates/bower/.bowerrc)" > /vagrant/.bowerrc
 
 
 chown vagrant:vagrant /home/vagrant/.zshrc
@@ -61,6 +65,16 @@ if [ ! -d "$VIRTUALENV_DIR" ]; then
     mkdir $VIRTUALENV_DIR
     virtualenv $VIRTUALENV_DIR
     chown -R vagrant:vagrant $VIRTUALENV_DIR
+fi
+
+
+echo "Configuring nodejs and bower with nvm..."
+NVM_DIR=/home/vagrant/env/nvm
+
+if [ ! -d "$NVM_DIR" ]; then
+    git clone https://github.com/creationix/nvm.git $NVM_DIR && cd $NVM_DIR && git checkout `git describe --abbrev=0 --tags`
+    chown -R vagrant:vagrant $NVM_DIR
+    sudo -Hu vagrant bash -c "source $NVM_DIR/nvm.sh && nvm install stable && npm install gulp bower -g"
 fi
 
 

--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -41,6 +41,12 @@ export PROJECT_NAME
 echo "$(envsubst < /tmp/templates/zsh/zprofile)" > /home/vagrant/.zprofile
 cp /tmp/templates/zsh/zshrc /home/vagrant/.zshrc
 
+
+echo "$(envsubst < /tmp/templates/fabric/fabfile.py)" > /vagrant/fabfile.py           
+echo "$(envsubst < /tmp/templates/tox/tox.ini)" > /vagrant/tox.ini                    
+echo "$(envsubst < /tmp/templates/env/environments.json)" > /vagrant/environments.json
+
+
 chown vagrant:vagrant /home/vagrant/.zshrc
 chown vagrant:vagrant /home/vagrant/.zprofile
 chsh -s $(which zsh) vagrant
@@ -78,7 +84,6 @@ if [ ! -d  "$PROJECT_DIR" ]; then
     echo "$(envsubst < /tmp/templates/django/settings_local.py)" > $PROJECT_DIR/settings/local.py
     echo "$(envsubst < /tmp/templates/django/settings_staging.py)" > $PROJECT_DIR/settings/staging.py
     echo "$(envsubst < /tmp/templates/django/settings_testing.py)" > $PROJECT_DIR/settings/testing.py
-    echo "$(envsubst < /tmp/templates/tox/tox.ini)" > /home/vagrant/tox.ini
 
     cp -r /tmp/templates/django/utils $PROJECT_DIR
     cp -r /tmp/templates/django/core $PROJECT_DIR

--- a/provision/templates/bower/.bowerrc
+++ b/provision/templates/bower/.bowerrc
@@ -1,0 +1,9 @@
+{
+    "name": "${PROJECT_NAME}",
+    "version": "0.0.1",
+    "authors": [
+        "python <python@vincoorbis.com>"
+    ],
+    "description": "Rest api of ${PROJECT_NAME}",
+    "directory": "./assets/bower_components/"
+}

--- a/provision/templates/bower/bower.json
+++ b/provision/templates/bower/bower.json
@@ -1,0 +1,6 @@
+{
+  "name": "${PROJECT_NAME}",
+  "version": "0.0.1",
+  "dependencies": {},
+  "resolutions": {}
+}

--- a/provision/templates/django/api/urls.py
+++ b/provision/templates/django/api/urls.py
@@ -5,7 +5,7 @@ from django.conf.urls import include, url
 
 urlpatterns = [
     url(
-        r'^v1/', include('luke.api.v1.urls', namespace='v1')
+        r'^v1/', include('${PROJECT_NAME}.api.v1.urls', namespace='v1')
     ),
 ]
 

--- a/provision/templates/django/core/api/mixins/__init__.py
+++ b/provision/templates/django/core/api/mixins/__init__.py
@@ -26,7 +26,7 @@ class CreateModelMixin(object):
         create_serializer = self.get_serializer(
             data=data,
             action='create'
-            )
+        )
         create_serializer.is_valid(raise_exception=True)
         created_object = self.perform_create(create_serializer)
 

--- a/provision/templates/django/core/api/mixins/__init__.py
+++ b/provision/templates/django/core/api/mixins/__init__.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from django.http.request import QueryDict
+
 from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.settings import api_settings
@@ -9,18 +11,22 @@ class CreateModelMixin(object):
     Create a model instance.
     """
     def create(self, request, *args, **kwargs):
+        # Serializer that will be used to create the object.
         data = request.data
 
-        # Pass kwargs to data
-        if kwargs:
-            for key, value in kwargs.iteritems():
+        # Pass extra_data to request data.
+        if 'extra_data' in kwargs:
+            if isinstance(data, QueryDict):
+                data = {}
+
+            for key, value in kwargs['extra_data'].iteritems():
                 data.update({key: value})
 
         # Serializer that will be used to create the object.
         create_serializer = self.get_serializer(
             data=data,
             action='create'
-        )
+            )
         create_serializer.is_valid(raise_exception=True)
         created_object = self.perform_create(create_serializer)
 
@@ -50,30 +56,24 @@ class ListModelMixin(object):
     """
     List a queryset.
     """
-    def list(self, request, *args, **kwargs):
+    def list(
+        self,
+        request,
+        response_serializer='list',
+        queryset=None,
+        *args,
+        **kwargs
+    ):
+        if queryset is None:
+            queryset = self.filter_queryset(self.get_queryset())
 
-        queryset = self.filter_queryset(self.get_queryset(*args, **kwargs))
         page = self.paginate_queryset(queryset)
-
         if page is not None:
-            serializer = self.get_serializer(page, many=True, action='list')
-            return self.get_paginated_response(serializer.data)
-
-        serializer = self.get_serializer(queryset, many=True)
-        return Response(serializer.data)
-
-
-class CustomListModelMixin(object):
-    """
-    Mixin used to work with custom routes. List the result of the queryset
-    """
-    def custom_list(self, request, action='list', *args, **kwargs):
-
-        queryset = self.filter_queryset(self.get_queryset(*args, **kwargs))
-        page = self.paginate_queryset(queryset)
-
-        if page is not None:
-            serializer = self.get_serializer(page, many=True, action=action)
+            serializer = self.get_serializer(
+                page,
+                many=True,
+                action=response_serializer
+            )
             return self.get_paginated_response(serializer.data)
 
         serializer = self.get_serializer(queryset, many=True)
@@ -84,21 +84,19 @@ class RetrieveModelMixin(object):
     """
     Retrieve a model instance.
     """
-    def retrieve(self, request, *args, **kwargs):
+    def retrieve(
+        self,
+        request,
+        pk=None,
+        instance=None,
+        response_serializer='retrieve',
+        *args,
+        **kwargs
+    ):
+        if instance is None:
+            instance = self.get_object()
 
-        instance = self.get_object()
-        serializer = self.get_serializer(instance, action='retrieve')
-
-        return Response(serializer.data)
-
-
-class CustomRetrieveModelMixin(object):
-    """
-    Retrieve a model instance.
-    """
-    def custom_retrieve(self, request, action='retrieve', *args, **kwargs):
-        queryset = self.get_queryset()
-        serializer = self.get_serializer(queryset, action=action)
+        serializer = self.get_serializer(instance, action=response_serializer)
         return Response(serializer.data)
 
 
@@ -106,15 +104,25 @@ class UpdateModelMixin(object):
     """
     Update a model instance.
     """
-    def update(self, request, *args, **kwargs):
-        instance = self.get_object()
+    def update(
+        self,
+        request,
+        pk=None,
+        instance=None,
+        request_serializer='update',
+        response_serializer='retrieve',
+        *args,
+        **kwargs
+    ):
+        if instance is None:
+            instance = self.get_object()
 
         # Serializer that will be used to update the object.
         update_serializer = self.get_serializer(
             instance,
             data=request.data,
             partial=False,
-            action='update'
+            action=request_serializer
         )
         update_serializer.is_valid(raise_exception=True)
         updated_object = update_serializer.save()
@@ -122,7 +130,7 @@ class UpdateModelMixin(object):
         # Serializer that will be used to retrieve the object.
         retrieve_serializer = self.get_serializer(
             updated_object,
-            action='retrieve'
+            action=response_serializer
         )
         return Response(retrieve_serializer.data)
 
@@ -131,15 +139,25 @@ class PartialUpdateModelMixin(object):
     """
     Update a model instance (partially).
     """
-    def partial_update(self, request, *args, **kwargs):
-        instance = self.get_object()
+    def partial_update(
+        self,
+        request,
+        pk=None,
+        instance=None,
+        request_serializer='update',
+        response_serializer='retrieve',
+        *args,
+        **kwargs
+    ):
+        if instance is None:
+            instance = self.get_object()
 
         # Serializer that will be used to update the object.
         update_serializer = self.get_serializer(
             instance,
             data=request.data,
             partial=True,
-            action='update'
+            action=request_serializer
         )
         update_serializer.is_valid(raise_exception=True)
         updated_object = update_serializer.save()
@@ -147,7 +165,7 @@ class PartialUpdateModelMixin(object):
         # Serializer that will be used to retrieve the object.
         retrieve_serializer = self.get_serializer(
             updated_object,
-            action='retrieve'
+            action=response_serializer
         )
         return Response(retrieve_serializer.data)
 
@@ -156,9 +174,9 @@ class DestroyModelMixin(object):
     """
     Destroy a model instance.
     """
-    def destroy(self, request, *args, **kwargs):
-
-        instance = self.get_object()
+    def destroy(self, request, pk=None, instance=None, *args, **kwargs):
+        if instance is None:
+            instance = self.get_object()
 
         self.perform_destroy(instance)
         return Response(status=status.HTTP_204_NO_CONTENT)

--- a/provision/templates/django/core/api/serializers/base.py
+++ b/provision/templates/django/core/api/serializers/base.py
@@ -26,6 +26,7 @@ class DynamicFieldsMixin(object):
     iterable or a falsy value, then the serializer will ignore this and will
     have all the fields declared at load time.
     Example:
+
         >>> from rest_framework import serializers
         ...
         >>> class MySerializer(DynamicFieldsMixin, serializers.Serializer):
@@ -109,7 +110,7 @@ class ModelSerializer(DynamicFieldsMixin, AbsoluteUriMixin,
         kwargs = {self.lookup_field: getattr(obj, self.lookup_field)}
 
         #
-        # Using custom kwargs if any.
+        # Using custom lookup fields if any.
         #
         if self.custom_lookup_fields is not None:
             kwargs = {}

--- a/provision/templates/django/settings_base.py
+++ b/provision/templates/django/settings_base.py
@@ -60,7 +60,7 @@ TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
         'DIRS': [
-            os.path.realpath(os.path.join(BASE_DIR, 'templates'))
+            os.path.realpath(os.path.join(BASE_DIR, '..', 'templates'))
         ],
         'APP_DIRS': True,
         'OPTIONS': {
@@ -99,8 +99,7 @@ REST_FRAMEWORK = {
         'rest_framework.parsers.MultiPartParser'
     ),
     'DEFAULT_PAGINATION_CLASS': (
-        # Your project default_pagination class project/utils/pagination.py
-        'ProjectDefaultPagination'
+        '${PROJECT_NAME}.utils.pagination.ProjectDefaultPagination'
     ),
     'PAGE_SIZE': 24
 }
@@ -191,7 +190,7 @@ PRODUCTION = False
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/1.9/howto/static-files/
 
-STATIC_URL = '/assets/'
+STATIC_URL = '/static/'
 
 STATICFILES_DIRS = (
     os.path.realpath(os.path.join(BASE_DIR, '..', 'assets')),

--- a/provision/templates/django/settings_base.py
+++ b/provision/templates/django/settings_base.py
@@ -100,8 +100,7 @@ REST_FRAMEWORK = {
     ),
     'DEFAULT_PAGINATION_CLASS': (
         '${PROJECT_NAME}.utils.pagination.ProjectDefaultPagination'
-    ),
-    'PAGE_SIZE': 24
+    )
 }
 
 

--- a/provision/templates/django/settings_local.py
+++ b/provision/templates/django/settings_local.py
@@ -8,19 +8,7 @@ from . import *  # noqa
 # Debug
 DEBUG = True
 
-TEMPLATES[0]['OPTIONS']['debug'] = DEBUG
-
-
-# Application definition
-INSTALLED_APPS += (
-    'debug_toolbar',
-)
-
-
-MIDDLEWARE_CLASSES += (
-    'debug_toolbar.middleware.DebugToolbarMiddleware',
-)
-
+TEMPLATES[0]['OPTIONS']['debug'] = DEBUG  # noqa
 
 # Database
 # https://docs.djangoproject.com/en/1.9/ref/settings/#databases

--- a/provision/templates/env/environments.json
+++ b/provision/templates/env/environments.json
@@ -5,7 +5,8 @@
         "site_dir": "/home/vagrant/src/",
         "django_settings": "${PROJECT_NAME}.settings.local",
         "command_prefixes": [
-            "/home/vagrant/env/bin/activate"
+            "/home/vagrant/env/bin/activate",
+            "/home/vagrant/env/nvm/nvm.sh"
         ]
     }
 }

--- a/provision/templates/env/environments.json
+++ b/provision/templates/env/environments.json
@@ -3,7 +3,7 @@
         "user": "vagrant",
         "hosts": ["192.168.33.2"],
         "site_dir": "/home/vagrant/src/",
-        "django_settings": "luke.settings.local",
+        "django_settings": "${PROJECT_NAME}.settings.local",
         "command_prefixes": [
             "/home/vagrant/env/bin/activate"
         ]

--- a/provision/templates/fabric/fabfile.py
+++ b/provision/templates/fabric/fabfile.py
@@ -93,6 +93,18 @@ def createdb():
 
 
 @task
+def dropdb():
+    """Restore database.
+
+    Drop database named ${PROJECT_NAME}.
+
+    Usage:
+        >>>fab environment:vagrant dropdb.
+    """
+    urun('dropdb ${PROJECT_NAME}')
+
+
+@task
 def resetdb():
     """Restore database.
 
@@ -101,7 +113,7 @@ def resetdb():
     Usage:
         >>>fab environment:vagrant resetdb.
     """
-    urun('dropdb ${PROJECT_NAME}')
+    dropdb()
     createdb()
     migrate()
 
@@ -194,8 +206,8 @@ def collectstatic():
 
 
 @task
-def runtest():
-    """Run project.
+def runtests():
+    """Run of ${PROJECT_NAME}.
 
     Starts the development server inside the Vagrant VM.
 

--- a/provision/templates/fabric/fabfile.py
+++ b/provision/templates/fabric/fabfile.py
@@ -194,6 +194,20 @@ def collectstatic():
 
 
 @task
+def runtest():
+    """Run project.
+
+    Starts the development server inside the Vagrant VM.
+
+    Usage:
+        >>>fab environment:vagrant runserver.
+    """
+
+    with cd('/vagrant'):
+        run('tox')
+
+
+@task
 def runserver():
     """Run project.
 

--- a/provision/templates/fabric/fabfile.py
+++ b/provision/templates/fabric/fabfile.py
@@ -78,7 +78,7 @@ def createdb():
     Usage:
         >>>fab environment:vagrant createdb.
     """
-    urun('createdb luke -l en_US.UTF-8 -E UTF8 -T template0')
+    urun('createdb ${PROJECT_NAME} -l en_US.UTF-8 -E UTF8 -T template0')
 
 
 @task
@@ -90,7 +90,7 @@ def resetdb():
     Usage:
         >>>fab environment:vagrant resetdb.
     """
-    urun('dropdb luke')
+    urun('dropdb ${PROJECT_NAME}')
     createdb()
     migrate()
 

--- a/provision/templates/fabric/fabfile.py
+++ b/provision/templates/fabric/fabfile.py
@@ -214,7 +214,6 @@ def runtests():
     Usage:
         >>>fab environment:vagrant runserver.
     """
-
     with cd('/vagrant'):
         run('tox')
 

--- a/provision/templates/tox/tox.ini
+++ b/provision/templates/tox/tox.ini
@@ -41,7 +41,7 @@ commands =
 
 exclude = migrations
 
-application-import-names = luke
+application-import-names = ${PROJECT_NAME}
 
 
 
@@ -53,7 +53,7 @@ python_paths = src/
 
 testpaths = src/
 
-DJANGO_SETTINGS_MODULE = luke.settings.testing
+DJANGO_SETTINGS_MODULE = ${PROJECT_NAME}.settings.testing
 
 addopts =
         --doctest-modules
@@ -61,4 +61,4 @@ addopts =
 norecursedirs =
         .*
         src/requirements
-        src/luke/settings
+        src/${PROJECT_NAME}/settings

--- a/src/assets/.gitignore
+++ b/src/assets/.gitignore
@@ -1,0 +1,1 @@
+bower_components/

--- a/src/requirements/local.txt
+++ b/src/requirements/local.txt
@@ -1,4 +1,4 @@
 -r base.txt
 
 # Development tools
-django-debug-toolbar==1.6
+tox==2.6.0


### PR DESCRIPTION
### Tareas relacionadas.
[Update luke to django 1.9.](http://manoderecha.net/md/index.php/task/128624)

### Descripción del problema o característica.
Es necesario que los nuevos proyectos que usen API REST se creen con la nueva versión estable de Django.

### Descripción de la solución.
Actualizar todos los archivos donde se menciona o instala Django 1.8
Generar el fabfile, environments y tox desde el provision
Añadir bower y sus cofiguraciones para instalar dependencias del front
Se elimina django.debug.toolbar ya que es innecesario para las APIs
Crear las urls en la carpeta /uri quitar luke y colocar el nombre desde el provisionamiento
Agregar una función de fabric para correr los test "runtests"
Agregar una función de fabric para eliminar la BD sin hacer ssh "dropdb"

### Pruebas.